### PR TITLE
修改 MTU，与 TopSAP 默认值保持一致

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -44,6 +44,9 @@ if [ ! -e "/sys/class/net/tun0" ]; then
   exit 1
 fi
 
+# 更改MTU（与 topsap 的默认值保持一致）
+ip link set dev tun0 mtu 1300
+
 # 添加NAT转发，使其他请求可以走正常出口，不全部走代理，例如公网请求
 iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
 wait


### PR DESCRIPTION
根据 https://github.com/libra146/docker-topsap/issues/16 以及 https://github.com/libra146/docker-topsap/issues/20 讨论。

tun0 默认的 MTU 1500，这导致一些问题，例如无法传输大文件，无法 ssh 等。

在 `start.sh` 中修正这一问题。
